### PR TITLE
Do not convert moment.js dates to UTC

### DIFF
--- a/Resources/Public/JavaScript/MomentReplacement.js
+++ b/Resources/Public/JavaScript/MomentReplacement.js
@@ -6,7 +6,7 @@ if (window.jQuery) {
 			if (typeof language !== typeof undefined && language !== false) {
 				moment.locale(language);
 			}
-			let m = moment.utc($element.html());
+			let m = moment.parseZone($element.html());
 			jQuery(this).html(m.format($element.attr('data-format')));
 		});
 	});


### PR DESCRIPTION
When dates are parsed with the `moment.utc` function,
the resulting time point is UTC and will be displayed as such
when it is formatted. This means that the user will only see
UTC times, which is not very helpful. `moment.parseZone` keeps
the time zone specified on the timestamp.